### PR TITLE
feat(systemd): restart xibo-linux service every 24h

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,6 +43,20 @@
     - Reload systemd configuration
     - Restart xibo-linux service
 
+- name: Create restart-xibo service
+  template:
+    src: restart-xibo.service.j2
+    dest: /etc/systemd/system/restart-xibo.service
+  notify:
+    - Reload systemd configuration
+
+- name: Create restart-xibo timer
+  template:
+    src: restart-xibo.timer.j2
+    dest: /etc/systemd/system/restart-xibo.timer
+  notify:
+    - Reload systemd configuration
+
 - name: Create udev rule for monitor hotplug
   template:
     src: monitor-hotplug.rules.j2
@@ -81,5 +95,11 @@
 - name: Enable xibo-linux service
   systemd:
     name: xibo-linux.service
+    enabled: True
+    state: started
+
+- name: Enable restart-xibo timer
+  systemd:
+    name: restart-xibo.timer
     enabled: True
     state: started

--- a/templates/restart-xibo.service.j2
+++ b/templates/restart-xibo.service.j2
@@ -1,0 +1,6 @@
+[Unit]
+Description=Restart xibo-linux service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/systemctl try-restart xibo-linux.service

--- a/templates/restart-xibo.timer.j2
+++ b/templates/restart-xibo.timer.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=Restart the xibo-linux service daily
+Requisite=xibo-linux.service
+
+[Timer]
+OnCalendar=*-*-* 03:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/templates/xibo-linux.service.j2
+++ b/templates/xibo-linux.service.j2
@@ -12,7 +12,6 @@ User={{ xibo_linux_user }}
 Environment="DISPLAY=:0"
 Restart=always
 RestartSec=10
-RuntimeMaxSec=86400
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/xibo-linux.service.j2
+++ b/templates/xibo-linux.service.j2
@@ -12,6 +12,7 @@ User={{ xibo_linux_user }}
 Environment="DISPLAY=:0"
 Restart=always
 RestartSec=10
+RuntimeMaxSec=86400
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The RAM of the machine running xibo-linux slowly fills up to the point where it becomes unresponisve. Restarting the service frees up the RAM.